### PR TITLE
Fixing the >=, <=, != operators

### DIFF
--- a/src/generator/intermediate-to-blueprint.js
+++ b/src/generator/intermediate-to-blueprint.js
@@ -228,6 +228,7 @@ export default ({timers, states}) => {
                         const leftSymbol = getSymbol(left);
                         const rightSymbol = getSymbol(right);
                         const outSymbol = getSymbol(out);
+                        const opSymbol = operator == '<=' ? '\u2265' : (operator == '>='? '\u2264' : (operator == '!=' ? '\u2260' : operator));
                         return createCombinator(
                             bp,
                             type,
@@ -237,7 +238,7 @@ export default ({timers, states}) => {
                         ).setCondition({
                             left: leftSymbol,
                             right: rightSymbol,
-                            operator,
+                            operator: opSymbol,
                             countFromInput,
                             out: outSymbol
                         });

--- a/src/generator/intermediate-to-blueprint.js
+++ b/src/generator/intermediate-to-blueprint.js
@@ -228,7 +228,7 @@ export default ({timers, states}) => {
                         const leftSymbol = getSymbol(left);
                         const rightSymbol = getSymbol(right);
                         const outSymbol = getSymbol(out);
-                        const opSymbol = operator == '<=' ? '\u2265' : (operator == '>='? '\u2264' : (operator == '!=' ? '\u2260' : operator));
+                        const opSymbol = operator == '<=' ? '\u2264' : (operator == '>='? '\u2265' : (operator == '!=' ? '\u2260' : operator));
                         return createCombinator(
                             bp,
                             type,

--- a/src/generator/transpiler.js
+++ b/src/generator/transpiler.js
@@ -6,6 +6,6 @@ export default (lines) => {
     const stateMachine = textToStateMachine(lines);
     const intermediate = stateMachineToIntermediate(stateMachine);
     const blueprint = intermediateToBlueprint(intermediate);
-    console.log(stateMachine);
+
     return blueprint;
 };

--- a/src/generator/transpiler.js
+++ b/src/generator/transpiler.js
@@ -7,5 +7,5 @@ export default (lines) => {
     const intermediate = stateMachineToIntermediate(stateMachine);
     const blueprint = intermediateToBlueprint(intermediate);
 
-    return blueprint;
+    return stateMachine;
 };

--- a/src/generator/transpiler.js
+++ b/src/generator/transpiler.js
@@ -6,6 +6,6 @@ export default (lines) => {
     const stateMachine = textToStateMachine(lines);
     const intermediate = stateMachineToIntermediate(stateMachine);
     const blueprint = intermediateToBlueprint(intermediate);
-
-    return stateMachine;
+    console.log(stateMachine);
+    return blueprint;
 };


### PR DESCRIPTION
Looks like Factorio expects utf8 char codes for those operators.
2264 corresponds to <=
2265 corresponds to >=
2260 corresponds to !=

I was having a hell of a time figuring out why none of my generated circuits was doing anything. Turns out factorio will throw out entities it cant understand. When it tried to read in combinators with those ops, it would silently throw them out.

My ghetto version https://state-machine-fixed.herokuapp.com/ produces functioning blueprints