### PR TITLE
Fixed decider combinator outputing input count instead of 1

### DIFF
--- a/src/generator/state-machine-to-intermediate.js
+++ b/src/generator/state-machine-to-intermediate.js
@@ -118,7 +118,8 @@ const getIntermediateFormOf = ({left, right, operator, out}, isSecondarySignal) 
             mergedArray.push([{
                 left: getSymbolFor(leftVar),
                 right: getSymbolFor(rightVar),
-                operator,
+                operator: operator,
+                countFromInput: ['=', '<', '>', '<=', '>=', '!='].includes(operator) ? false : undefined,
                 out: getSymbolFor('INT_A')
             }, {
                 // Subtract old value of 'out' from result


### PR DESCRIPTION
Not really sure why this never got noticed, but seems to be an issue related to having two non-virtual signals compared. It attempts to output A with value "input count". This needs to be set to one.
![fix](https://user-images.githubusercontent.com/2334183/31855125-f38db4f2-b669-11e7-9924-e77c15ac2c6a.png)

```
timer T

10:
  T >= 600 => 20

20:
  reset T
  signal_green = (steam >= stone_brick)
  => 10
```