### PR TITLE
Adds moo lexer to parser to dramatically improve speed and memory usage

### DIFF
--- a/src/generator/text-to-state-machine.js
+++ b/src/generator/text-to-state-machine.js
@@ -1,8 +1,8 @@
 import nearley from 'nearley';
-import Grammar from './grammar.ne';
+import grammar from './grammar.ne';
 
 // import unparse from 'nearley-unparse';
-// console.log("dummy", unparse(Grammar));
+// console.log("dummy", unparse(grammar));
 
 const removeComments = (lines) => {
     return lines
@@ -11,7 +11,7 @@ const removeComments = (lines) => {
 };
 
 export default (code) => {
-    const parser = new nearley.Parser(Grammar.ParserRules, Grammar.ParserStart);
+    const parser = new nearley.Parser(nearley.Grammar.fromCompiled(grammar));
     const lines = removeComments(code);
 
     parser.feed(lines);


### PR DESCRIPTION
Tokenizes integers, signal names, and whitespace into single chunks now resulting in much smaller parsing tables.

See: https://nearley.js.org/docs/tokenizers

This was motivated by noticing that as I was adding states to a reasonably sized program, it got slower and slower until the browser refused to allocate it any more memory and would crash the tab. The machine in question was only up to 14 states or so and about 70 lines long with several comments.