### PR TITLE
Add support for alphanumeric labels

### DIFF
--- a/src/generator/grammar.ne
+++ b/src/generator/grammar.ne
@@ -25,8 +25,7 @@ const lexer = moo.compile({
   assign: "=",
   label: ":",
   integer: /[0-9]+/,
-  id: {match: /[a-zA-Z_]+/, type: moo.keywords({timer: 'timer', reset: 'reset'})},
-  string: /[a-zA-Z][a-zA-Z_0-9]*/,
+  id: {match: /[a-zA-Z][a-zA-Z_0-9]*/, type: moo.keywords({timer: 'timer', reset: 'reset'})},
 });
 %}
 
@@ -59,7 +58,7 @@ state
     }
   %}
 stateLabel
-  -> _ (%integer | %id | %string) %label {% (data) => data[1][0].value %}
+  -> _ (%integer | %id) %label {% (data) => data[1][0].value %}
 statement
   -> _ %id _ "=" _ expression {%
     ([, signal, , , , expression]) => {
@@ -86,7 +85,7 @@ statement
     })
   %}
 transition
-  -> _ expression:? _ "=>" _ (%integer | %id | %string) {%
+  -> _ expression:? _ "=>" _ (%integer | %id) {%
     ([, condition, , , , goto]) => {
       if(condition != null) {
         return {

--- a/src/generator/grammar.ne
+++ b/src/generator/grammar.ne
@@ -58,7 +58,7 @@ state
     }
   %}
 stateLabel
-  -> _ %integer %label {% (data) => +data[1].value %}
+  -> _ (%integer | %id) %label {% (data) => data[1][0].value %}
 statement
   -> _ %id _ "=" _ expression {%
     ([, signal, , , , expression]) => {
@@ -85,16 +85,16 @@ statement
     })
   %}
 transition
-  -> _ expression:? _ "=>" _ %integer {%
+  -> _ expression:? _ "=>" _ (%integer | %id) {%
     ([, condition, , , , goto]) => {
       if(condition != null) {
         return {
           condition: condition,
-          goto: +goto.value
+          goto: goto[0].value
         };
       } else {
         return {
-          goto: +goto.value
+          goto: goto[0].value
         };
       }
     }

--- a/src/generator/grammar.ne
+++ b/src/generator/grammar.ne
@@ -26,6 +26,7 @@ const lexer = moo.compile({
   label: ":",
   integer: /[0-9]+/,
   id: {match: /[a-zA-Z_]+/, type: moo.keywords({timer: 'timer', reset: 'reset'})},
+  string: /[a-zA-Z][a-zA-Z_0-9]*/,
 });
 %}
 
@@ -58,7 +59,7 @@ state
     }
   %}
 stateLabel
-  -> _ (%integer | %id) %label {% (data) => data[1][0].value %}
+  -> _ (%integer | %id | %string) %label {% (data) => data[1][0].value %}
 statement
   -> _ %id _ "=" _ expression {%
     ([, signal, , , , expression]) => {
@@ -85,7 +86,7 @@ statement
     })
   %}
 transition
-  -> _ expression:? _ "=>" _ (%integer | %id) {%
+  -> _ expression:? _ "=>" _ (%integer | %id | %string) {%
     ([, condition, , , , goto]) => {
       if(condition != null) {
         return {

--- a/src/generator/grammar.ne
+++ b/src/generator/grammar.ne
@@ -58,7 +58,8 @@ state
     }
   %}
 stateLabel
-  -> _ (%integer | %id) %label {% (data) => data[1][0].value %}
+  -> _ %integer %label {% (data) => +data[1].value %}
+  |  _ (%id) %label {% (data) => data[1][0].value %}
 statement
   -> _ %id _ "=" _ expression {%
     ([, signal, , , , expression]) => {
@@ -90,11 +91,11 @@ transition
       if(condition != null) {
         return {
           condition: condition,
-          goto: goto[0].value
+          goto: !isNaN(+goto) ? +goto : goto[0].value
         };
       } else {
         return {
-          goto: goto[0].value
+          goto: !isNaN(+goto) ? +goto : goto[0].value
         };
       }
     }

--- a/src/generator/state-machine-to-intermediate.js
+++ b/src/generator/state-machine-to-intermediate.js
@@ -162,16 +162,10 @@ function generateNextLabel(state, states) {
     }
 
     const ends = state.statements.map(s => s.start + s.operations.length);
-    let end = getMaxRounded(ends);
+    let end = Math.max(0, Math.max(...ends) + 1);
     let tmp = numericStateEnd;
     numericStateEnd = numericStateEnd + end;
     return tmp;
-}
-
-function getMaxRounded(ends) {
-    let end = Math.max(...ends) + 1;
-    end = Math.max(end, 0); // prevent -infinity when ends is empty
-    return Math.ceil(end / 10) * 10; // Round to the nex multiple of 10
 }
 
 function endOfLastNumericState(states) {
@@ -179,7 +173,7 @@ function endOfLastNumericState(states) {
         .filter(({state}) => typeof state === 'number')
         .map(({statements}) => statements.map(s => s.start + s.operations.length))
         .flat();
-    return getMaxRounded(ends);
+    return Math.max(0, Math.max(...ends) + 1);
 }
 
 /**

--- a/src/generator/state-machine-to-intermediate.js
+++ b/src/generator/state-machine-to-intermediate.js
@@ -155,19 +155,17 @@ const getIntermediateFormOf = ({left, right, operator, out}, isSecondarySignal) 
 };
 
 // Helper function to generate next available numeric
-// let numericStateEnd;
-// function generateNextLabel(state, states) {
-//     if (!numericStateEnd) {
-//         numericStateEnd = endOfLastNumericState(states);
-//     }
-//
-//     const ends = state.statements.map(s => s.start + s.operations.length);
-//     return numericStateEnd
-// }
-
-//Placeholder function for now
+let numericStateEnd;
 function generateNextLabel(state, states) {
-    return endOfLastNumericState(states);
+    if (numericStateEnd === undefined) {
+        numericStateEnd = endOfLastNumericState(states);
+    }
+
+    const ends = state.statements.map(s => s.start + s.operations.length);
+    let end = getMaxRounded(ends);
+    let tmp = numericStateEnd;
+    numericStateEnd = numericStateEnd + end;
+    return tmp;
 }
 
 function getMaxRounded(ends) {
@@ -190,6 +188,7 @@ function endOfLastNumericState(states) {
  * into a blueprint
  */
 export default ({timers, states}) => {
+    numericStateEnd = undefined;
     // Map of string labels to numeric labels
     const labelMap = {};
 
@@ -259,11 +258,12 @@ export default ({timers, states}) => {
     });
 
     // Generate numeric labels for each label name
-    states.forEach(({state, statements}, index) => {
+    states.forEach((currentstate, index) => {
+        let {state, statements} = currentstate;
         // Generate numeric label if string
         if(typeof state === 'string') {
             if(!labelMap[state]) {
-                const start = generateNextLabel(state, states);
+                const start = generateNextLabel(currentstate, states);
                 labelMap[state] = start;
                 statements = statements.map((statement) => ({
                     ...statement,

--- a/src/generator/text-to-state-machine.js
+++ b/src/generator/text-to-state-machine.js
@@ -18,13 +18,22 @@ export default (code) => {
     const {results} = parser;
     const [result] = results;
 
-    const {states} = result;
+    const {states, timers} = result;
 
-    // Require state numbers to be positive
-    states.forEach(({state}) => {
-        if(state <= 0) {
-            throw new Error(`State ${state} is not a positive number. State values must be postive in order to prevent non-determinism during blueprint construction`);
+    // Convert all integer states to int
+    states.forEach(({state}, index) => {
+        if(!isNaN(state)) {
+            states[index].state = parseInt(state);
         }
+    });
+
+    // Convert all integer transitions to int
+    states.forEach(({transitions}, stateIndex) => {
+        transitions.forEach(({goto}, transitionIndex) => {
+            if(!isNaN(goto)) {
+                states[stateIndex].transitions[transitionIndex].goto = parseInt(goto);
+            }
+        });
     });
 
     // Check transitions to ensure they only go to states which exist
@@ -36,5 +45,5 @@ export default (code) => {
         });
     });
 
-    return result;
+    return {states, timers};
 };

--- a/src/generator/text-to-state-machine.js
+++ b/src/generator/text-to-state-machine.js
@@ -36,6 +36,13 @@ export default (code) => {
         });
     });
 
+    // Require state numbers to be positive
+    states.forEach(({state}) => {
+        if(state <= 0) {
+            throw new Error(`State ${state} is not a positive number. State values must be postive in order to prevent non-determinism during blueprint construction`);
+        }
+    });
+
     // Check transitions to ensure they only go to states which exist
     states.forEach(({state, transitions}) => {
         transitions.forEach(({goto}) => {

--- a/src/generator/text-to-state-machine.js
+++ b/src/generator/text-to-state-machine.js
@@ -18,7 +18,7 @@ export default (code) => {
     const {results} = parser;
     const [result] = results;
 
-    const {states, timers} = result;
+    const {states} = result;
 
     // Require state numbers to be positive
     states.forEach(({state}) => {
@@ -36,5 +36,5 @@ export default (code) => {
         });
     });
 
-    return {states, timers};
+    return result;
 };

--- a/src/generator/text-to-state-machine.js
+++ b/src/generator/text-to-state-machine.js
@@ -20,22 +20,6 @@ export default (code) => {
 
     const {states, timers} = result;
 
-    // Convert all integer states to int
-    states.forEach(({state}, index) => {
-        if(!isNaN(state)) {
-            states[index].state = parseInt(state);
-        }
-    });
-
-    // Convert all integer transitions to int
-    states.forEach(({transitions}, stateIndex) => {
-        transitions.forEach(({goto}, transitionIndex) => {
-            if(!isNaN(goto)) {
-                states[stateIndex].transitions[transitionIndex].goto = parseInt(goto);
-            }
-        });
-    });
-
     // Require state numbers to be positive
     states.forEach(({state}) => {
         if(state <= 0) {

--- a/test/state-machine-to-intermediate.test.js
+++ b/test/state-machine-to-intermediate.test.js
@@ -190,7 +190,7 @@ describe('state-machine-to-intermediate', () => {
                         out: 'INT_A'
                     }], [{
                         branch: 'INT_A',
-                        goto: 10
+                        goto: 9
                     }]]
                 }, {
                     start: 6,
@@ -202,9 +202,9 @@ describe('state-machine-to-intermediate', () => {
                     }]]
                 }]
             }, {
-                state: 10,
+                state: 9,
                 statements: [{
-                    start: 10,
+                    start: 9,
                     operations: [[{
                         guard: true
                     }], [{
@@ -214,7 +214,7 @@ describe('state-machine-to-intermediate', () => {
                         out: 'signal_Y'
                     }]]
                 }, {
-                    start: 12,
+                    start: 11,
                     operations: [[{
                         guard: true // TODO: Figure out the best way to share guards
                     }], [{
@@ -271,9 +271,9 @@ describe('state-machine-to-intermediate', () => {
         const expected = {
             timers: [],
             states: [{
-                state: 110,
+                state: 105,
                 statements: [{
-                    start: 110,
+                    start: 105,
                     operations: [[{
                         guard: true
                     }], [{
@@ -283,7 +283,7 @@ describe('state-machine-to-intermediate', () => {
                         out: 'signal_X'
                     }]]
                 }, {
-                    start: 112,
+                    start: 107,
                     operations: [[{
                         left: 'signal_X',
                         right: 3,
@@ -307,12 +307,12 @@ describe('state-machine-to-intermediate', () => {
                         goto: 100
                     }]]
                 }, {
-                    start: 116,
+                    start: 111,
                     operations: [[{
                         guard: true
                     }], [{
                         branch: 'GUARD',
-                        goto: 110
+                        goto: 105
                     }]]
                 }]
             }, {
@@ -333,7 +333,7 @@ describe('state-machine-to-intermediate', () => {
                         guard: true // TODO: Figure out the best way to share guards
                     }], [{
                         branch: 'GUARD',
-                        goto: 110
+                        goto: 105
                     }]]
                 }]
             }]
@@ -418,7 +418,7 @@ describe('state-machine-to-intermediate', () => {
                         out: 'INT_A'
                     }], [{
                         branch: 'INT_A',
-                        goto: 10
+                        goto: 9
                     }]]
                 }, {
                     start: 6,
@@ -430,9 +430,9 @@ describe('state-machine-to-intermediate', () => {
                     }]]
                 }]
             }, {
-                state: 10,
+                state: 9,
                 statements: [{
-                    start: 10,
+                    start: 9,
                     operations: [[{
                         guard: true
                     }], [{
@@ -442,7 +442,7 @@ describe('state-machine-to-intermediate', () => {
                         out: 'signal_Y'
                     }]]
                 }, {
-                    start: 12,
+                    start: 11,
                     operations: [[{
                         guard: true // TODO: Figure out the best way to share guards
                     }], [{

--- a/test/state-machine-to-intermediate.test.js
+++ b/test/state-machine-to-intermediate.test.js
@@ -229,4 +229,232 @@ describe('state-machine-to-intermediate', () => {
 
         expect(result).toEqual(expected);
     });
+
+    test('should convert a parse tree of two-state machine with a mix of labels to equivalent intermediate form', () => {
+        const stateMachine = {
+            timers: [],
+            states: [{
+                state: "start",
+                statements: [{
+                    left: 'X',
+                    right: 1,
+                    operator: '+',
+                    out: 'X'
+                }],
+                transitions: [{
+                    condition: {
+                        left: {
+                            left: 'X',
+                            right: 3,
+                            operator: '%'
+                        },
+                        right: 0,
+                        operator: '=',
+                    },
+                    goto: 100
+                }, {
+                    goto: "start"
+                }]
+            }, {
+                state: 100,
+                statements: [{
+                    left: 'Y',
+                    right: 1,
+                    operator: '+',
+                    out: 'Y'
+                }],
+                transitions: [{
+                    goto: "start"
+                }]
+            }]
+        };
+        const expected = {
+            timers: [],
+            states: [{
+                state: 110,
+                statements: [{
+                    start: 110,
+                    operations: [[{
+                        guard: true
+                    }], [{
+                        left: 'GUARD',
+                        right: 1,
+                        operator: '*',
+                        out: 'signal_X'
+                    }]]
+                }, {
+                    start: 112,
+                    operations: [[{
+                        left: 'signal_X',
+                        right: 3,
+                        operator: '%',
+                        out: 'INT_A'
+                    }], [{
+                        left: 'INT_A',
+                        right: 0,
+                        operator: '=',
+                        countFromInput: false,
+                        out: 'INT_A'
+                    }, {
+                        guard: true
+                    }], [{
+                        left: 'INT_A',
+                        right: 'GUARD',
+                        operator: '*',
+                        out: 'INT_A'
+                    }], [{
+                        branch: 'INT_A',
+                        goto: 100
+                    }]]
+                }, {
+                    start: 116,
+                    operations: [[{
+                        guard: true
+                    }], [{
+                        branch: 'GUARD',
+                        goto: 110
+                    }]]
+                }]
+            }, {
+                state: 100,
+                statements: [{
+                    start: 100,
+                    operations: [[{
+                        guard: true
+                    }], [{
+                        left: 'GUARD',
+                        right: 1,
+                        operator: '*',
+                        out: 'signal_Y'
+                    }]]
+                }, {
+                    start: 102,
+                    operations: [[{
+                        guard: true // TODO: Figure out the best way to share guards
+                    }], [{
+                        branch: 'GUARD',
+                        goto: 110
+                    }]]
+                }]
+            }]
+        };
+
+        const result = stateMachineToIntermediate(stateMachine);
+
+        expect(result).toEqual(expected);
+    });
+
+    test('should convert a parse tree of two-state machine with alphanumerics labels to equivalent intermediate form', () => {
+        const stateMachine = {
+            timers: [],
+            states: [{
+                state: "state1",
+                statements: [{
+                    left: 'X',
+                    right: 1,
+                    operator: '+',
+                    out: 'X'
+                }],
+                transitions: [{
+                    condition: {
+                        left: {
+                            left: 'X',
+                            right: 3,
+                            operator: '%'
+                        },
+                        right: 0,
+                        operator: '=',
+                    },
+                    goto: "state2"
+                }, {
+                    goto: "state1"
+                }]
+            }, {
+                state: "state2",
+                statements: [{
+                    left: 'Y',
+                    right: 1,
+                    operator: '+',
+                    out: 'Y'
+                }],
+                transitions: [{
+                    goto: "state1"
+                }]
+            }]
+        };
+        const expected = {
+            timers: [],
+            states: [{
+                state: 0,
+                statements: [{
+                    start: 0,
+                    operations: [[{
+                        guard: true
+                    }], [{
+                        left: 'GUARD',
+                        right: 1,
+                        operator: '*',
+                        out: 'signal_X'
+                    }]]
+                }, {
+                    start: 2,
+                    operations: [[{
+                        left: 'signal_X',
+                        right: 3,
+                        operator: '%',
+                        out: 'INT_A'
+                    }], [{
+                        left: 'INT_A',
+                        right: 0,
+                        operator: '=',
+                        countFromInput: false,
+                        out: 'INT_A'
+                    }, {
+                        guard: true
+                    }], [{
+                        left: 'INT_A',
+                        right: 'GUARD',
+                        operator: '*',
+                        out: 'INT_A'
+                    }], [{
+                        branch: 'INT_A',
+                        goto: 10
+                    }]]
+                }, {
+                    start: 6,
+                    operations: [[{
+                        guard: true
+                    }], [{
+                        branch: 'GUARD',
+                        goto: 0
+                    }]]
+                }]
+            }, {
+                state: 10,
+                statements: [{
+                    start: 10,
+                    operations: [[{
+                        guard: true
+                    }], [{
+                        left: 'GUARD',
+                        right: 1,
+                        operator: '*',
+                        out: 'signal_Y'
+                    }]]
+                }, {
+                    start: 12,
+                    operations: [[{
+                        guard: true // TODO: Figure out the best way to share guards
+                    }], [{
+                        branch: 'GUARD',
+                        goto: 0
+                    }]]
+                }]
+            }]
+        };
+
+        const result = stateMachineToIntermediate(stateMachine);
+
+        expect(result).toEqual(expected);
+    });
 });

--- a/test/state-machine-to-intermediate.test.js
+++ b/test/state-machine-to-intermediate.test.js
@@ -115,4 +115,118 @@ describe('state-machine-to-intermediate', () => {
 
         expect(result).toEqual(expected);
     });
+
+    test('should convert a parse tree of two-state machine with labels to equivalent intermediate form', () => {
+        const stateMachine = {
+            timers: [],
+            states: [{
+                state: "start",
+                statements: [{
+                    left: 'X',
+                    right: 1,
+                    operator: '+',
+                    out: 'X'
+                }],
+                transitions: [{
+                    condition: {
+                        left: {
+                            left: 'X',
+                            right: 3,
+                            operator: '%'
+                        },
+                        right: 0,
+                        operator: '=',
+                    },
+                    goto: "end"
+                }, {
+                    goto: "start"
+                }]
+            }, {
+                state: "end",
+                statements: [{
+                    left: 'Y',
+                    right: 1,
+                    operator: '+',
+                    out: 'Y'
+                }],
+                transitions: [{
+                    goto: "start"
+                }]
+            }]
+        };
+        const expected = {
+            timers: [],
+            states: [{
+                state: 0,
+                statements: [{
+                    start: 0,
+                    operations: [[{
+                        guard: true
+                    }], [{
+                        left: 'GUARD',
+                        right: 1,
+                        operator: '*',
+                        out: 'signal_X'
+                    }]]
+                }, {
+                    start: 2,
+                    operations: [[{
+                        left: 'signal_X',
+                        right: 3,
+                        operator: '%',
+                        out: 'INT_A'
+                    }], [{
+                        left: 'INT_A',
+                        right: 0,
+                        operator: '=',
+                        countFromInput: false,
+                        out: 'INT_A'
+                    }, {
+                        guard: true
+                    }], [{
+                        left: 'INT_A',
+                        right: 'GUARD',
+                        operator: '*',
+                        out: 'INT_A'
+                    }], [{
+                        branch: 'INT_A',
+                        goto: 10
+                    }]]
+                }, {
+                    start: 6,
+                    operations: [[{
+                        guard: true
+                    }], [{
+                        branch: 'GUARD',
+                        goto: 0
+                    }]]
+                }]
+            }, {
+                state: 10,
+                statements: [{
+                    start: 10,
+                    operations: [[{
+                        guard: true
+                    }], [{
+                        left: 'GUARD',
+                        right: 1,
+                        operator: '*',
+                        out: 'signal_Y'
+                    }]]
+                }, {
+                    start: 12,
+                    operations: [[{
+                        guard: true // TODO: Figure out the best way to share guards
+                    }], [{
+                        branch: 'GUARD',
+                        goto: 0
+                    }]]
+                }]
+            }]
+        };
+
+        const result = stateMachineToIntermediate(stateMachine);
+
+        expect(result).toEqual(expected);
+    });
 });

--- a/test/text-to-state-machine.test.js
+++ b/test/text-to-state-machine.test.js
@@ -181,4 +181,57 @@ describe('text-to-state-machine', () => {
 
         expect(result).toEqual(expected);
     });
+
+    test('should convert the source code for a 2-state machine with named labels to state machine notation', () => {
+        const source =
+            'start:\n' +
+            '    X = X + 1\n' +
+            '    X % 3 == 0 => end\n' +
+            '    => start\n' +
+            'end:\n' +
+            '    Y = Y + 1\n' +
+            '    => start\n';
+
+        const expected = {
+            timers: [],
+            states: [{
+                state: "start",
+                statements: [{
+                    left: 'X',
+                    right: 1,
+                    operator: '+',
+                    out: 'X'
+                }],
+                transitions: [{
+                    condition: {
+                        left: {
+                            left: 'X',
+                            right: 3,
+                            operator: '%'
+                        },
+                        right: 0,
+                        operator: '=',
+                    },
+                    goto: "end"
+                }, {
+                    goto: "start"
+                }]
+            }, {
+                state: "end",
+                statements: [{
+                    left: 'Y',
+                    right: 1,
+                    operator: '+',
+                    out: 'Y'
+                }],
+                transitions: [{
+                    goto: "start"
+                }]
+            }]
+        };
+
+        const result = textToStateMachine(source);
+
+        expect(result).toEqual(expected);
+    });
 });

--- a/test/text-to-state-machine.test.js
+++ b/test/text-to-state-machine.test.js
@@ -234,4 +234,110 @@ describe('text-to-state-machine', () => {
 
         expect(result).toEqual(expected);
     });
+
+    test('should convert the source code for a 2-state machine with alphanumerics labels to state machine notation', () => {
+        const source =
+            'state1:\n' +
+            '    X = X + 1\n' +
+            '    X % 3 == 0 => state2\n' +
+            '    => state1\n' +
+            'state2:\n' +
+            '    Y = Y + 1\n' +
+            '    => state1\n';
+
+        const expected = {
+            timers: [],
+            states: [{
+                state: "state1",
+                statements: [{
+                    left: 'X',
+                    right: 1,
+                    operator: '+',
+                    out: 'X'
+                }],
+                transitions: [{
+                    condition: {
+                        left: {
+                            left: 'X',
+                            right: 3,
+                            operator: '%'
+                        },
+                        right: 0,
+                        operator: '=',
+                    },
+                    goto: "state2"
+                }, {
+                    goto: "state1"
+                }]
+            }, {
+                state: "state2",
+                statements: [{
+                    left: 'Y',
+                    right: 1,
+                    operator: '+',
+                    out: 'Y'
+                }],
+                transitions: [{
+                    goto: "state1"
+                }]
+            }]
+        };
+
+        const result = textToStateMachine(source);
+
+        expect(result).toEqual(expected);
+    });
+
+    test('should convert the source code for a 2-state machine with a mix of label types to state machine notation', () => {
+        const source =
+            'start:\n' +
+            '    X = X + 1\n' +
+            '    X % 3 == 0 => 10\n' +
+            '    => start\n' +
+            '10:\n' +
+            '    Y = Y + 1\n' +
+            '    => start\n';
+
+        const expected = {
+            timers: [],
+            states: [{
+                state: "start",
+                statements: [{
+                    left: 'X',
+                    right: 1,
+                    operator: '+',
+                    out: 'X'
+                }],
+                transitions: [{
+                    condition: {
+                        left: {
+                            left: 'X',
+                            right: 3,
+                            operator: '%'
+                        },
+                        right: 0,
+                        operator: '=',
+                    },
+                    goto: 10
+                }, {
+                    goto: "start"
+                }]
+            }, {
+                state: 10,
+                statements: [{
+                    left: 'Y',
+                    right: 1,
+                    operator: '+',
+                    out: 'Y'
+                }],
+                transitions: [{
+                    goto: "start"
+                }]
+            }]
+        };
+
+        const result = textToStateMachine(source);
+
+        expect(result).toEqual(expected);
+    });
 });


### PR DESCRIPTION
This pull request add support for alphanumeric labels.
I have added tests to it.

Currently, it only works with labels without numbers, I'm new to the Moo library and I couldn't get it to match my string "type", it always match number or id (if I put string above them it breaks everything).
If this parsing issue is fixed, the rest of the code should support label names with numbers.